### PR TITLE
check if report is for windows 10 enterprise before creating mitre he…

### DIFF
--- a/ATAPHtmlReport/ATAPHtmlReport.psm1
+++ b/ATAPHtmlReport/ATAPHtmlReport.psm1
@@ -1337,8 +1337,10 @@ function Get-ATAPHtmlReport {
 						if($RiskScore -and ($os -match "Win32NT" -and $Title -match "Win")){
 							htmlElement 'button' @{type = 'button'; class = 'navButton'; id = 'riskScoreBtn'; onclick = "clickButton('2')" } { "Risk Score" }
 						}
-						if($MITRE -and ($os -match "Win32NT" -and $Title -match "Win")){
-							htmlElement 'button' @{type = 'button'; class = 'navButton'; id = 'MITREBtn'; onclick = "clickButton('6')" } { "MITRE ATT&CK" }
+						if($MITRE){
+							if($Title -eq "Windows 10 Report" -and $os -match "Win32NT"){
+								htmlElement 'button' @{type = 'button'; class = 'navButton'; id = 'MITREBtn'; onclick = "clickButton('6')" } { "MITRE ATT&CK" }
+							}
 						}
 						htmlElement 'button' @{type = 'button'; class = 'navButton'; id = 'settingsOverviewBtn'; onclick = "clickButton('4')" } { "Hardening Settings" }
 						htmlElement 'button' @{type = 'button'; class = 'navButton'; id = 'referenceBtn'; onclick = "clickButton('3')" } { "About Us" }
@@ -1847,20 +1849,25 @@ function Get-ATAPHtmlReport {
 					}
 
 					if($MITRE) {
-						htmlElement 'div' @{class = 'tabContent'; id = 'MITRE' } {
-							htmlElement 'h1'@{} {"Version of CIS in MITRE Mapping and tests"}
-							htmlElement 'p'@{} {Compare-EqualCISVersions -Title:$Title -BasedOn:$BasedOn}
-							htmlElement 'h1'@{} {"MITRE ATT&CK"}
-							htmlElement 'p'@{} {'To get a quick overview of how good your system is hardened in terms of the MITRE ATT&CK Framework we made a heatmap.'}
-							htmlElement 'h2' @{id = 'CurrentATT&CKHeatpmap'} {"Current ATT&CK heatmap on tested System: "}
+						if($Title -eq "Windows 10 Report" -and $os -match "Win32NT"){
+							htmlElement 'div' @{class = 'tabContent'; id = 'MITRE' } {
+								htmlElement 'h1'@{} {"Version of CIS in MITRE Mapping and tests"}
+								htmlElement 'p'@{} {Compare-EqualCISVersions -Title:$Title -BasedOn:$BasedOn}
+								htmlElement 'h1'@{} {"MITRE ATT&CK"}
+								htmlElement 'p'@{} {'To get a quick overview of how good your system is hardened in terms of the MITRE ATT&CK Framework we made a heatmap.'}
+								htmlElement 'h2' @{id = 'CurrentATT&CKHeatpmap'} {"Current ATT&CK heatmap on tested System: "}
 
-							$Mappings = $Sections | 
-							Where-Object { $_.Title -eq "CIS Benchmarks" } | 
-							ForEach-Object { return $_.SubSections } | 
-							ForEach-Object { return $_.AuditInfos } | 
-							Merge-CisAuditsToMitreMap
+								$Mappings = $Sections | 
+								Where-Object { $_.Title -eq "CIS Benchmarks" } | 
+								ForEach-Object { return $_.SubSections } | 
+								ForEach-Object { return $_.AuditInfos } | 
+								Merge-CisAuditsToMitreMap
 
-							ConvertTo-HtmlTable $Mappings.map
+								ConvertTo-HtmlTable $Mappings.map
+							}
+						}
+						else {
+							Write-Host -ForegroundColor DarkYellow "Warning: Mitre Heatmap can only be used on a Windows System together with `"Windows 10 Report`". The Mitre Heatmap will not be generated"
 						}
 					}
 


### PR DESCRIPTION
checks if report is for windows 10 enterprise before generating mitre heatmap. Prints an error if not.
The risk score has a similar check, but in case of an error the riskscore is still created with an empty table. I didnt want to create an empty table, because this might look unprofessional in the finished html report, so i am only printing the error message to the console and the mitre tab is not included in the html report in case of an error